### PR TITLE
[update] grab_one_flagの処理を改善

### DIFF
--- a/src/info-reader/artifact-reader.cpp
+++ b/src/info-reader/artifact-reader.cpp
@@ -23,7 +23,7 @@ static errr grab_one_artifact_flag(artifact_type *a_ptr, concptr what)
         }
     }
 
-    if (a_ptr->gen_flags.grab_one_flag(k_info_gen_flags, std::string(what)))
+    if (FlagGroup<TRG>::grab_one_flag(a_ptr->gen_flags, k_info_gen_flags, what))
         return 0;
 
     msg_format(_("未知の伝説のアイテム・フラグ '%s'。", "Unknown artifact flag '%s'."), what);

--- a/src/info-reader/ego-reader.cpp
+++ b/src/info-reader/ego-reader.cpp
@@ -23,7 +23,7 @@ static bool grab_one_ego_item_flag(ego_item_type *e_ptr, concptr what)
         }
     }
 
-    if (e_ptr->gen_flags.grab_one_flag(k_info_gen_flags, std::string(what)))
+    if (FlagGroup<TRG>::grab_one_flag(e_ptr->gen_flags, k_info_gen_flags, what))
         return 0;
 
     msg_format(_("未知の名のあるアイテム・フラグ '%s'。", "Unknown ego-item flag '%s'."), what);

--- a/src/info-reader/kind-reader.cpp
+++ b/src/info-reader/kind-reader.cpp
@@ -24,7 +24,7 @@ static errr grab_one_kind_flag(object_kind *k_ptr, concptr what)
         }
     }
 
-    if (k_ptr->gen_flags.grab_one_flag(k_info_gen_flags, std::string(what)))
+    if (FlagGroup<TRG>::grab_one_flag(k_ptr->gen_flags, k_info_gen_flags, what))
         return 0;
 
     msg_format(_("未知のアイテム・フラグ '%s'。", "Unknown object flag '%s'."), what);

--- a/src/util/flag-group.h
+++ b/src/util/flag-group.h
@@ -407,13 +407,26 @@ public:
         }
     }
 
-    bool grab_one_flag(const std::unordered_map<std::string_view, FlagType> &dict, std::string_view what)
+    /**
+     * @brief 文字列からフラグへのマップを指定した検索キーで検索し、
+     *        見つかった場合はフラグ集合に該当するフラグをセットする
+     *
+     * @tparam Map std::map<string_view, FlagType> もしくは std::unordered_map<string_view, FlagType>
+     * @param fg フラグをセットするフラグ集合
+     * @param dict 文字列からフラグへのマップ
+     * @param what マップの検索キー
+     * @return bool 検索キーでフラグが見つかり、フラグをセットした場合 true
+     *              見つからなかった場合 false
+     */
+    template <typename Map>
+    static bool grab_one_flag(FlagGroup<FlagType>& fg, const Map &dict, std::string_view what)
     {
-        if (dict.count(what) == 0)
-            return FALSE;
+        auto it = dict.find(what);
+        if (it == dict.end())
+            return false;
 
-        set(dict.at(what));
-        return TRUE;
+        fg.set(it->second);
+        return true;
     }
 
 private:


### PR DESCRIPTION
メソッドではなくサービス関数で処理するのが相応しいので、
静的メンバ関数にする。
countとatでは2回検索して非効率なので、findで存在を調べて
setはfindで見つけたイテレータで処理する。
string_viewに渡す時はstringクラスにする必要が無いので、
生成のコストをカットできるようにconcptrのまま渡す。