### PR TITLE
[refactor] spoil_mon_descの呼び出し引数を整理

### DIFF
--- a/src/wizard/monster-info-spoiler.cpp
+++ b/src/wizard/monster-info-spoiler.cpp
@@ -68,7 +68,7 @@ static concptr attr_to_text(monster_race *r_ptr)
     return _("変な色の", "Icky");
 }
 
-spoiler_output_status spoil_mon_desc(concptr fname, bool show_all, bool only_ridable, race_flags8 RF8_flags)
+spoiler_output_status spoil_mon_desc(concptr fname, std::function<bool(const monster_race *)> filter_monster)
 {
     player_type dummy;
     u16b why = 2;
@@ -111,9 +111,7 @@ spoiler_output_status spoil_mon_desc(concptr fname, bool show_all, bool only_rid
     for (int i = 0; i < n; i++) {
         monster_race *r_ptr = &r_info[who[i]];
         concptr name = (r_name + r_ptr->name);
-        if (!show_all && none_bits(r_ptr->flags8, RF8_flags))
-            continue;
-        if (only_ridable && none_bits(r_ptr->flags7, RF7_RIDING))
+        if (filter_monster && !filter_monster(r_ptr))
             continue;
 
         char name_buf[41];
@@ -158,13 +156,6 @@ spoiler_output_status spoil_mon_desc(concptr fname, bool show_all, bool only_rid
     }
     return SPOILER_OUTPUT_SUCCESS;
 }
-
-/*!
- * @brief モンスター簡易情報のスポイラー出力を行うメインルーチン /
- * Create a spoiler file for monsters   -BEN-
- * @param fname 生成ファイル名
- */
-spoiler_output_status spoil_mon_desc_all(concptr fname) { return spoil_mon_desc(fname, TRUE, FALSE, RF8_WILD_ALL); }
 
 /*!
  * @brief 関数ポインタ用の出力関数 /

--- a/src/wizard/monster-info-spoiler.h
+++ b/src/wizard/monster-info-spoiler.h
@@ -3,7 +3,10 @@
 #include "system/angband.h"
 #include "wizard/spoiler-util.h"
 
-enum race_flags8 : uint32_t;
+#include <functional>
+
+struct monster_race;
+
 spoiler_output_status spoil_mon_desc_all(concptr fname);
-spoiler_output_status spoil_mon_desc(concptr fname, bool show_all, bool only_ridable, race_flags8 RF8_flags);
+spoiler_output_status spoil_mon_desc(concptr fname, std::function<bool(const monster_race *)> filter_monster = nullptr);
 spoiler_output_status spoil_mon_info(concptr fname);

--- a/src/wizard/wizard-spoiler.cpp
+++ b/src/wizard/wizard-spoiler.cpp
@@ -15,10 +15,12 @@
 #include "io/input-key-acceptor.h"
 #include "main/sound-of-music.h"
 #include "monster-race/monster-race.h"
+#include "monster-race/race-flags7.h"
 #include "monster-race/race-flags8.h"
 #include "system/angband-version.h"
 #include "term/screen-processor.h"
 #include "util/angband-files.h"
+#include "util/bit-flags-calculator.h"
 #include "util/int-char-converter.h"
 #include "util/sort.h"
 #include "view/display-messages.h"
@@ -191,7 +193,7 @@ void exe_output_spoilers(void)
             status = spoil_fixed_artifact("artifact.txt");
             break;
         case '3':
-            status = spoil_mon_desc_all("mon-desc.txt");
+            status = spoil_mon_desc("mon-desc.txt");
             break;
         case '4':
             status = spoil_mon_info("mon-info.txt");
@@ -235,42 +237,42 @@ spoiler_output_status output_all_spoilers(void)
     if (status != SPOILER_OUTPUT_SUCCESS)
         return status;
 
-    status = spoil_mon_desc_all("mon-desc.txt");
+    status = spoil_mon_desc("mon-desc.txt");
     if (status != SPOILER_OUTPUT_SUCCESS)
         return status;
 
-    status = spoil_mon_desc("mon-desc-ridable.txt", TRUE, TRUE, RF8_WILD_ALL);
+    status = spoil_mon_desc("mon-desc-ridable.txt", [](const monster_race *r_ptr) { return any_bits(r_ptr->flags7, RF7_RIDING); });
     if (status != SPOILER_OUTPUT_SUCCESS)
         return status;
 
-    status = spoil_mon_desc("mon-desc-wildonly.txt", FALSE, FALSE, RF8_WILD_ONLY);
+    status = spoil_mon_desc("mon-desc-wildonly.txt", [](const monster_race *r_ptr) { return any_bits(r_ptr->flags8, RF8_WILD_ONLY); });
     if (status != SPOILER_OUTPUT_SUCCESS)
         return status;
-    status = spoil_mon_desc("mon-desc-town.txt", FALSE, FALSE, RF8_WILD_TOWN);
+    status = spoil_mon_desc("mon-desc-town.txt", [](const monster_race *r_ptr) { return any_bits(r_ptr->flags8, RF8_WILD_TOWN); });
     if (status != SPOILER_OUTPUT_SUCCESS)
         return status;
-    status = spoil_mon_desc("mon-desc-shore.txt", FALSE, FALSE, RF8_WILD_SHORE);
+    status = spoil_mon_desc("mon-desc-shore.txt", [](const monster_race *r_ptr) { return any_bits(r_ptr->flags8, RF8_WILD_SHORE); });
     if (status != SPOILER_OUTPUT_SUCCESS)
         return status;
-    status = spoil_mon_desc("mon-desc-ocean.txt", FALSE, FALSE, RF8_WILD_OCEAN);
+    status = spoil_mon_desc("mon-desc-ocean.txt", [](const monster_race *r_ptr) { return any_bits(r_ptr->flags8, RF8_WILD_OCEAN); });
     if (status != SPOILER_OUTPUT_SUCCESS)
         return status;
-    status = spoil_mon_desc("mon-desc-waste.txt", FALSE, FALSE, RF8_WILD_WASTE);
+    status = spoil_mon_desc("mon-desc-waste.txt", [](const monster_race *r_ptr) { return any_bits(r_ptr->flags8, RF8_WILD_WASTE); });
     if (status != SPOILER_OUTPUT_SUCCESS)
         return status;
-    status = spoil_mon_desc("mon-desc-wood.txt", FALSE, FALSE, RF8_WILD_WOOD);
+    status = spoil_mon_desc("mon-desc-wood.txt", [](const monster_race *r_ptr) { return any_bits(r_ptr->flags8, RF8_WILD_WOOD); });
     if (status != SPOILER_OUTPUT_SUCCESS)
         return status;
-    status = spoil_mon_desc("mon-desc-volcano.txt", FALSE, FALSE, RF8_WILD_VOLCANO);
+    status = spoil_mon_desc("mon-desc-volcano.txt", [](const monster_race *r_ptr) { return any_bits(r_ptr->flags8, RF8_WILD_VOLCANO); });
     if (status != SPOILER_OUTPUT_SUCCESS)
         return status;
-    status = spoil_mon_desc("mon-desc-mountain.txt", FALSE, FALSE, RF8_WILD_MOUNTAIN);
+    status = spoil_mon_desc("mon-desc-mountain.txt", [](const monster_race *r_ptr) { return any_bits(r_ptr->flags8, RF8_WILD_MOUNTAIN); });
     if (status != SPOILER_OUTPUT_SUCCESS)
         return status;
-    status = spoil_mon_desc("mon-desc-grass.txt", FALSE, FALSE, RF8_WILD_GRASS);
+    status = spoil_mon_desc("mon-desc-grass.txt", [](const monster_race *r_ptr) { return any_bits(r_ptr->flags8, RF8_WILD_GRASS); });
     if (status != SPOILER_OUTPUT_SUCCESS)
         return status;
-    status = spoil_mon_desc("mon-desc-wildall.txt", FALSE, FALSE, RF8_WILD_ALL);
+    status = spoil_mon_desc("mon-desc-wildall.txt", [](const monster_race *r_ptr) { return any_bits(r_ptr->flags8, RF8_WILD_ALL); });
     if (status != SPOILER_OUTPUT_SUCCESS)
         return status;
 


### PR DESCRIPTION
2種類のスイッチに1つのビットフラグと、引数が増えて複雑化
している。やりたい事は出力するモンスターをフィルタリング
することなので、シンプルにモンスターをフィルタリングする
コールバック関数をラムダ式で渡すようにする。